### PR TITLE
Update bootstrap dependency due to security warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "babel-eslint": "^6.0.2",
     "babel-plugin-object-assign": "^1.2.1",
     "babel-preset-jason": "^3.0.0",
-    "bootstrap": "^3.3.5",
+    "bootstrap": "^4.1.5",
     "component-metadata-loader": "^3.0.1",
     "cpy": "^3.4.1",
     "eslint": "^3.0.0",


### PR DESCRIPTION
We're getting github security warnings for having 3.3.5 defined as a dependency

```
In Bootstrap before 4.1.2, XSS is possible in the data-target property of scrollspy. This is similar to CVE-2018-14042.
```

This is only used in demo, checked it and doesn't seem to break anything.